### PR TITLE
Bug fix for mouseover and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.un~
+*.swp
 node_modules
 dist
 *.zip

--- a/src/scripts/StackedBarTrack.js
+++ b/src/scripts/StackedBarTrack.js
@@ -338,6 +338,10 @@ const StackedBarTrack = (HGC, ...args) => {
 
       const tileId = this.tileToLocalId([zoomLevel, Math.floor(tilePos)]);
       const fetchedTile = this.fetchedTiles[tileId];
+
+      if (!fetchedTile)
+        return '';
+
       const matrixRow = fetchedTile.matrix[posInTileX];
       const row = fetchedTile.mouseOverData[posInTileX];
 


### PR DESCRIPTION
Check if the tile that the mouse moves over is loaded before trying to get data from it. This should prevent and undefined error.

Added a few file types to the gitignore.